### PR TITLE
Don't search artwork for failed requests

### DIFF
--- a/scrap.sh
+++ b/scrap.sh
@@ -896,6 +896,11 @@ for scraper in ${scrapers[@]};
 						 #ID Game
 						 content=$(curl "$url") 
 						 
+						 #Don't check art after a failed request to screenscraper
+						 if [[ $content == "" ]]; then
+						 	echo -e "Couldn't match $romNameNoExtension, ${YELLOW}skipping${NONE}"
+						    continue;
+						 fi
 						 #echo $content;
 						 
 						 


### PR DESCRIPTION
Skip checking for artwork if screenscraper request has failed