### PR TITLE
Screenscraper error

### DIFF
--- a/scrap.sh
+++ b/scrap.sh
@@ -898,10 +898,15 @@ for scraper in ${scrapers[@]};
 						 #ID Game
 						 content=$(curl "$url") 
 						 
-						 #Don't check art after a failed request to screenscraper
+						 #Don't check art after a failed curl request
 						 if [[ $content == "" ]]; then
-						 	echo -e "Couldn't match $romNameNoExtension, ${YELLOW}skipping${NONE}"
+						 	echo -e "Request failed to send for $romNameNoExtension, ${YELLOW}skipping${NONE}"
 						    continue;
+						 fi
+						 #Don't check art if screenscraper can't find a match
+					     if [[ $content == *"Erreur"* ]]; then
+  						 	echo -e "Couldn't find a match for $romNameNoExtension, ${YELLOW}skipping${NONE}"
+							continue;
 						 fi
 						 #echo $content;
 						 

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ rm -f ~/storage/shared/scrap.log  &> ~/storage/shared/pegasus_installer_log.log
 
 rm -rf ~/storage &>> /dev/null
 termux-setup-storage
-echo -e "Pegasus installer 1.3"
+echo -e "Pegasus installer 1.3b"
 echo -e  "${BOLD}Hi!${NONE} We're gonna start configuring your ${GREEN}Android Device${NONE}"
 echo -e  "We recommend you to hide the virtual keyboard by swiping from the left of the screen."
 echo -e  "${RED}Read before continuing${NONE}"


### PR DESCRIPTION
When screenscraper fails to find a match it returns the error `"Erreur : Rom/Iso/Dossier non trouvée !"`

This will skip checking artwork for all roms that return `"Erreur`" in their response